### PR TITLE
feat: add Laravel & dbt to resume tools, remove internship availability line

### DIFF
--- a/typst/template.typ
+++ b/typst/template.typ
@@ -114,9 +114,8 @@
 //   date: "Oct 2024",
 // )
 == Skills and Additional Information
-- *Internship Availability*: 11 May 2026 - 31 July 2026, NOC Malaysia (3-month programme), no additional visa sponsorship required.
 - *Programming Languages*: Python, TypeScript, JavaScript, SQL, HTML, CSS, Bash
-- *Frameworks and Tools*: Next.js, SvelteKit, FastAPI, NestJS, Fastify, Node.js, Tailwind CSS, PostgreSQL, MySQL, MongoDB, PyTorch, Hugging Face, Scikit-Learn, NumPy, Pandas, Git, LaTeX
+- *Frameworks and Tools*: Next.js, SvelteKit, Laravel, FastAPI, NestJS, Fastify, Node.js, Tailwind CSS, PostgreSQL, MySQL, MongoDB, dbt, PyTorch, Hugging Face, Scikit-Learn, NumPy, Pandas, Git, LaTeX
 - *Deployment Experience*: Google Cloud Platform, Firebase, Supabase, Docker, Kubernetes, Helm, Kubeflow
 - *Personal Traits*: Natural Leader, Team Player, Fast Learner, Critical Thinker
 


### PR DESCRIPTION
- Added Laravel and dbt to *Frameworks and Tools* in the resume template.
- Removed the *Internship Availability* line from the Skills section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)